### PR TITLE
docs: add comparison with phpseclib/bcmath_compat to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ This polyfill uses [phpseclib](https://github.com/phpseclib/phpseclib)'s BigInte
   - PHP >= 7.3.0: Use `bcscale()` without arguments
   - PHP < 7.3.0: Use `max(0, strlen(bcadd('0', '0')) - 2)`
 
+## 🔄 Key Differences from phpseclib/bcmath_compat
+
+| Feature | phpseclib/bcmath_compat | bcmath-polyfill |
+|---------|------------------------|-----------------|
+| **PHP 8.4 functions** | ❌ Not supported | ✅ Full support |
+| `bcfloor()` | ❌ | ✅ |
+| `bcceil()` | ❌ | ✅ |
+| `bcround()` | ❌ | ✅ |
+| **PHP 8.2+ deprecations** | ⚠️ Warnings | ✅ Fixed |
+| **Test suite pollution** | ⚠️ Issues | ✅ Fixed |
+| **Active maintenance** | ❌ Limited | ✅ Active |
+| **CI/CD (PHP versions)** | GitHub Actions (8.1, 8.2, 8.3) | GitHub Actions (8.1, 8.2, 8.3, 8.4) |
+
+### Migration from phpseclib/bcmath_compat
+
+Switching is seamless - no code changes required:
+
+```bash
+# Remove old package
+composer remove phpseclib/bcmath_compat
+
+# Install bcmath-polyfill
+composer require nanasess/bcmath-polyfill
+```
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Summary
- Add detailed comparison table between phpseclib/bcmath_compat and bcmath-polyfill
- Include migration guide for seamless switching
- Update v0.0.1 release notes with accurate CI/CD information

## Changes
- **README.md**: Added "Key Differences from phpseclib/bcmath_compat" section with:
  - Comprehensive comparison table
  - Simple migration instructions
- **Release Notes**: Fixed CI/CD comparison to accurately show both projects use GitHub Actions, with PHP 8.4 support being the key difference

## Why?
Users need to understand the differences between the two packages and how to migrate. This documentation makes it clear that bcmath-polyfill offers:
- PHP 8.4 function support (bcfloor, bcceil, bcround)
- Bug fixes for PHP 8.2+ deprecations
- Active maintenance
- Extended CI/CD coverage including PHP 8.4

🤖 Generated with [Claude Code](https://claude.ai/code)