### PR TITLE
feat(benchmarks): add benchmarking framework for BCMath operations

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -1,0 +1,151 @@
+name: Run Benchmark (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of iterations per test'
+        required: false
+        default: '10000'
+        type: string
+      post_comment:
+        description: 'Post results as comment on PR'
+        required: false
+        default: false
+        type: boolean
+      pr_number:
+        description: 'PR number to post comment (if enabled)'
+        required: false
+        type: string
+
+  push:
+    branches:
+      - main
+      - 'feature/**'
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'benchmarks/**'
+      - 'composer.json'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    strategy:
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php-version }} Benchmark
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: bcmath
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction
+
+      - name: Update benchmark iterations
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          # Update iterations if custom value provided
+          ITERATIONS="${{ github.event.inputs.iterations }}"
+          if [ -n "$ITERATIONS" ]; then
+            sed -i "s/private const ITERATIONS = [0-9]\+;/private const ITERATIONS = $ITERATIONS;/" benchmarks/BenchmarkRunner.php
+            WARMUP=$((ITERATIONS / 10))
+            sed -i "s/private const WARMUP_ITERATIONS = [0-9]\+;/private const WARMUP_ITERATIONS = $WARMUP;/" benchmarks/BenchmarkRunner.php
+          fi
+
+      - name: Run benchmarks
+        id: benchmark
+        run: |
+          echo "## Running benchmark with PHP ${{ matrix.php-version }}"
+          php benchmarks/run-benchmarks.php | tee benchmark_output.txt
+
+          # Generate reports
+          php benchmarks/run-benchmarks.php -f markdown -o benchmark_results.md
+          php benchmarks/run-benchmarks.php -f json -o benchmark_results.json
+
+          # Extract summary
+          echo "BENCHMARK_SUMMARY<<EOF" >> $GITHUB_OUTPUT
+          tail -n 5 benchmark_output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Get native vs polyfill ratio
+          RATIO=$(tail -n 2 benchmark_output.txt | head -n 1 | grep -oP '\d+\.\d+x' || echo "N/A")
+          echo "performance_ratio=$RATIO" >> $GITHUB_OUTPUT
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-php${{ matrix.php-version }}
+          path: |
+            benchmark_results.md
+            benchmark_results.json
+            benchmark_output.txt
+
+      - name: Format benchmark comment
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.post_comment == 'true' && github.event.inputs.pr_number != ''
+        id: format_comment
+        run: |
+          cat > comment.md << 'EOL'
+          ## 🚀 Performance Benchmark Results (Manual Run)
+
+          ### Configuration
+          - **PHP Version**: ${{ matrix.php-version }}
+          - **Iterations**: ${{ github.event.inputs.iterations || '10000' }}
+          - **Commit**: ${{ github.sha }}
+
+          ### Performance Ratio
+          **Polyfill is ${{ steps.benchmark.outputs.performance_ratio }} compared to native BCMath**
+
+          <details>
+          <summary>📊 Detailed Results</summary>
+
+          EOL
+
+          cat benchmark_results.md >> comment.md
+
+          cat >> comment.md << 'EOL'
+
+          </details>
+
+          ### Summary
+          ```
+          ${{ steps.benchmark.outputs.BENCHMARK_SUMMARY }}
+          ```
+
+          ---
+          <sub>🤖 Triggered manually via GitHub Actions</sub>
+          EOL
+
+          echo "COMMENT<<EOF" >> $GITHUB_OUTPUT
+          cat comment.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post results to PR
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.post_comment == 'true' && github.event.inputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `${{ steps.format_comment.outputs.COMMENT }}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.inputs.pr_number }},
+              body: comment
+            });
+
+            console.log('Results posted to PR #${{ github.event.inputs.pr_number }}');

--- a/.github/workflows/benchmark-on-merge.yml
+++ b/.github/workflows/benchmark-on-merge.yml
@@ -1,0 +1,111 @@
+name: Benchmark on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  benchmark:
+    # Only run if the PR was merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: bcmath
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction
+
+      - name: Run benchmarks
+        id: benchmark
+        run: |
+          # Run the benchmark and capture output
+          php benchmarks/run-benchmarks.php > benchmark_output.txt
+
+          # Also generate markdown report
+          php benchmarks/run-benchmarks.php -f markdown -o benchmark_results.md
+
+          # Extract summary for PR comment
+          echo "BENCHMARK_SUMMARY<<EOF" >> $GITHUB_OUTPUT
+          tail -n 5 benchmark_output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Format benchmark results
+        id: format
+        run: |
+          # Read the markdown results
+          RESULTS=$(cat benchmark_results.md)
+
+          # Create formatted comment
+          cat > comment.md << 'EOL'
+          ## 🚀 Performance Benchmark Results
+
+          Benchmark executed on merge to `main` branch from PR #${{ github.event.pull_request.number }}
+
+          ### Configuration
+          - **Iterations per test**: 10,000
+          - **PHP Version**: 8.2
+          - **Extension**: bcmath (native) vs polyfill
+
+          ### Results
+
+          <details>
+          <summary>📊 Detailed Benchmark Results (click to expand)</summary>
+
+          EOL
+
+          # Add the benchmark results
+          cat benchmark_results.md >> comment.md
+
+          # Add closing details tag and summary
+          cat >> comment.md << 'EOL'
+
+          </details>
+
+          ### Summary
+
+          ```
+          ${{ steps.benchmark.outputs.BENCHMARK_SUMMARY }}
+          ```
+
+          ---
+
+          <sub>🤖 Generated automatically by GitHub Actions</sub>
+          EOL
+
+          # Save formatted comment
+          echo "COMMENT<<EOF" >> $GITHUB_OUTPUT
+          cat comment.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post benchmark results to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `${{ steps.format.outputs.COMMENT }}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: comment
+            });
+
+            console.log('Benchmark results posted to PR #' + context.payload.pull_request.number);

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -1,0 +1,161 @@
+name: Benchmark on PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'benchmarks/**'
+      - 'composer.json'
+
+  issue_comment:
+    types: [created]
+
+jobs:
+  benchmark:
+    # Run on PR or when someone comments "/benchmark"
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/benchmark'))
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Checkout the PR branch for pull_request events
+          # For issue_comment events, checkout the PR's head
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+
+      - name: Fetch PR details for comment trigger
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        id: pr_details
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.pr.outputs.number }}
+            });
+            core.setOutput('head_sha', pr.data.head.sha);
+            return pr.data;
+
+      - name: Checkout PR for comment trigger
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr_details.outputs.head_sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: bcmath
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction
+
+      - name: Run benchmarks (Quick mode for PR)
+        id: benchmark
+        run: |
+          # Use fewer iterations for PR checks (1000 instead of 10000)
+          sed -i 's/private const ITERATIONS = [0-9]\+;/private const ITERATIONS = 1000;/' benchmarks/BenchmarkRunner.php
+          sed -i 's/private const WARMUP_ITERATIONS = [0-9]\+;/private const WARMUP_ITERATIONS = 100;/' benchmarks/BenchmarkRunner.php
+
+          # Run benchmark
+          php benchmarks/run-benchmarks.php | tee benchmark_output.txt
+
+          # Generate markdown report
+          php benchmarks/run-benchmarks.php -f markdown -o benchmark_results.md
+
+          # Extract summary
+          echo "BENCHMARK_SUMMARY<<EOF" >> $GITHUB_OUTPUT
+          tail -n 5 benchmark_output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Get ratio
+          RATIO=$(tail -n 2 benchmark_output.txt | head -n 1 | grep -oP '\d+\.\d+x' || echo "N/A")
+          echo "performance_ratio=$RATIO" >> $GITHUB_OUTPUT
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '🚀 Performance Benchmark Results'
+
+      - name: Format benchmark comment
+        id: format
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            TRIGGER_MSG="Triggered by @${{ github.event.comment.user.login }} with \`/benchmark\` command"
+          else
+            TRIGGER_MSG="Automatically triggered by PR update"
+          fi
+
+          cat > comment.md << EOL
+          ## 🚀 Performance Benchmark Results
+
+          ### Configuration
+          - **PHP Version**: 8.2
+          - **Iterations**: 1,000 (quick mode for PR)
+          - **Commit**: \`${{ github.event.pull_request.head.sha || steps.pr_details.outputs.head_sha }}\`
+
+          ### Performance Summary
+          **Polyfill is ${{ steps.benchmark.outputs.performance_ratio }} compared to native BCMath**
+
+          <details>
+          <summary>📊 View Detailed Results</summary>
+
+          EOL
+
+          # Add first 20 rows of results for brevity
+          head -n 35 benchmark_results.md >> comment.md
+
+          cat >> comment.md << 'EOL'
+
+          *Note: Showing partial results. Run with `/benchmark` comment for full results.*
+
+          </details>
+
+          ### Quick Summary
+          ```
+          ${{ steps.benchmark.outputs.BENCHMARK_SUMMARY }}
+          ```
+
+          ---
+          <sub>🤖 ${TRIGGER_MSG}</sub>
+          <sub>💡 Comment with `/benchmark` to re-run this test</sub>
+          EOL
+
+          echo "COMMENT<<EOF" >> $GITHUB_OUTPUT
+          cat comment.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: ${{ steps.format.outputs.COMMENT }}
+          edit-mode: replace

--- a/benchmarks/BenchmarkRunner.php
+++ b/benchmarks/BenchmarkRunner.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace bcmath_compat\Benchmarks;
+
+use bcmath_compat\BCMath;
+
+class BenchmarkRunner
+{
+    private const ITERATIONS = 10000;
+    private const WARMUP_ITERATIONS = 1000;
+
+    private array $results = [];
+    private bool $nativeAvailable;
+
+    public function __construct()
+    {
+        $this->nativeAvailable = extension_loaded('bcmath');
+    }
+
+    public function run(): void
+    {
+        $this->printHeader();
+
+        // Basic operations
+        $this->benchmarkBasicOperations();
+
+        // Advanced operations
+        $this->benchmarkAdvancedOperations();
+
+        // Large number operations
+        $this->benchmarkLargeNumbers();
+
+        // High precision operations
+        $this->benchmarkHighPrecision();
+
+        $this->printSummary();
+    }
+
+    private function benchmarkBasicOperations(): void
+    {
+        $this->printSection('Basic Operations');
+
+        $testCases = [
+            ['name' => 'Small numbers (10 digits)', 'a' => '1234567890', 'b' => '9876543210', 'scale' => 0],
+            ['name' => 'Decimals (scale=10)', 'a' => '123.4567890123', 'b' => '987.6543210987', 'scale' => 10],
+            ['name' => 'Medium numbers (50 digits)', 'a' => str_repeat('12345', 10), 'b' => str_repeat('98765', 10), 'scale' => 0],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $this->printSubSection($testCase['name']);
+
+            // Addition
+            $this->benchmark('bcadd', function() use ($testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcadd($testCase['a'], $testCase['b'], $testCase['scale']);
+                }
+            }, function() use ($testCase) {
+                return BCMath::add($testCase['a'], $testCase['b'], $testCase['scale']);
+            }, $testCase['name']);
+
+            // Subtraction
+            $this->benchmark('bcsub', function() use ($testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcsub($testCase['a'], $testCase['b'], $testCase['scale']);
+                }
+            }, function() use ($testCase) {
+                return BCMath::sub($testCase['a'], $testCase['b'], $testCase['scale']);
+            }, $testCase['name']);
+
+            // Multiplication
+            $this->benchmark('bcmul', function() use ($testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcmul($testCase['a'], $testCase['b'], $testCase['scale']);
+                }
+            }, function() use ($testCase) {
+                return BCMath::mul($testCase['a'], $testCase['b'], $testCase['scale']);
+            }, $testCase['name']);
+
+            // Division
+            $this->benchmark('bcdiv', function() use ($testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcdiv($testCase['a'], $testCase['b'], $testCase['scale']);
+                }
+            }, function() use ($testCase) {
+                return BCMath::div($testCase['a'], $testCase['b'], $testCase['scale']);
+            }, $testCase['name']);
+        }
+    }
+
+    private function benchmarkAdvancedOperations(): void
+    {
+        $this->printSection('Advanced Operations');
+
+        $testCases = [
+            ['name' => 'Power (small exponent)', 'base' => '2', 'exp' => '10', 'scale' => 0],
+            ['name' => 'Power (large base)', 'base' => '12345', 'exp' => '5', 'scale' => 0],
+            ['name' => 'Square root', 'number' => '123456789', 'scale' => 10],
+            ['name' => 'Modulo', 'a' => '1234567890', 'b' => '123', 'scale' => 0],
+        ];
+
+        // Power operations
+        $powerCases = array_filter($testCases, fn($c) => isset($c['exp']));
+        foreach ($powerCases as $testCase) {
+            $this->printSubSection($testCase['name']);
+
+            $this->benchmark('bcpow', function() use ($testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcpow($testCase['base'], $testCase['exp'], $testCase['scale']);
+                }
+            }, function() use ($testCase) {
+                return BCMath::pow($testCase['base'], $testCase['exp'], $testCase['scale']);
+            }, $testCase['name']);
+        }
+
+        // Square root
+        $sqrtCase = array_filter($testCases, fn($c) => isset($c['number']))[2];
+        $this->printSubSection($sqrtCase['name']);
+
+        $this->benchmark('bcsqrt', function() use ($sqrtCase) {
+            if ($this->nativeAvailable) {
+                return \bcsqrt($sqrtCase['number'], $sqrtCase['scale']);
+            }
+        }, function() use ($sqrtCase) {
+            return BCMath::sqrt($sqrtCase['number'], $sqrtCase['scale']);
+        }, $sqrtCase['name']);
+
+        // Modulo
+        $modCase = array_filter($testCases, fn($c) => isset($c['a']) && isset($c['b']))[3];
+        $this->printSubSection($modCase['name']);
+
+        $this->benchmark('bcmod', function() use ($modCase) {
+            if ($this->nativeAvailable) {
+                return \bcmod($modCase['a'], $modCase['b'], $modCase['scale']);
+            }
+        }, function() use ($modCase) {
+            return BCMath::mod($modCase['a'], $modCase['b'], $modCase['scale']);
+        }, $modCase['name']);
+    }
+
+    private function benchmarkLargeNumbers(): void
+    {
+        $this->printSection('Large Number Operations');
+
+        $testCases = [
+            ['name' => '100 digits', 'digits' => 100],
+            ['name' => '500 digits', 'digits' => 500],
+            ['name' => '1000 digits', 'digits' => 1000],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $this->printSubSection($testCase['name']);
+
+            $a = $this->generateNumber($testCase['digits']);
+            $b = $this->generateNumber($testCase['digits']);
+
+            // Addition
+            $this->benchmark('bcadd', function() use ($a, $b) {
+                if ($this->nativeAvailable) {
+                    return \bcadd($a, $b);
+                }
+            }, function() use ($a, $b) {
+                return BCMath::add($a, $b);
+            }, $testCase['name']);
+
+            // Multiplication (with smaller numbers to avoid timeout)
+            if ($testCase['digits'] <= 500) {
+                $smallA = substr($a, 0, 50);
+                $smallB = substr($b, 0, 50);
+
+                $this->benchmark('bcmul', function() use ($smallA, $smallB) {
+                    if ($this->nativeAvailable) {
+                        return \bcmul($smallA, $smallB);
+                    }
+                }, function() use ($smallA, $smallB) {
+                    return BCMath::mul($smallA, $smallB);
+                }, $testCase['name'] . ' (first 50 digits)');
+            }
+        }
+    }
+
+    private function benchmarkHighPrecision(): void
+    {
+        $this->printSection('High Precision Operations');
+
+        $testCases = [
+            ['name' => 'Scale 20', 'scale' => 20],
+            ['name' => 'Scale 50', 'scale' => 50],
+            ['name' => 'Scale 100', 'scale' => 100],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $this->printSubSection($testCase['name']);
+
+            $a = '123.456789';
+            $b = '987.654321';
+
+            // Division (most affected by scale)
+            $this->benchmark('bcdiv', function() use ($a, $b, $testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcdiv($a, $b, $testCase['scale']);
+                }
+            }, function() use ($a, $b, $testCase) {
+                return BCMath::div($a, $b, $testCase['scale']);
+            }, $testCase['name']);
+
+            // Square root
+            $this->benchmark('bcsqrt', function() use ($a, $testCase) {
+                if ($this->nativeAvailable) {
+                    return \bcsqrt($a, $testCase['scale']);
+                }
+            }, function() use ($a, $testCase) {
+                return BCMath::sqrt($a, $testCase['scale']);
+            }, $testCase['name']);
+        }
+    }
+
+    private function benchmark(string $operation, callable $native, callable $polyfill, string $context = ''): void
+    {
+        $nativeTime = null;
+        $nativeMemory = null;
+
+        if ($this->nativeAvailable && $native !== null) {
+            // Warmup
+            for ($i = 0; $i < self::WARMUP_ITERATIONS; $i++) {
+                $native();
+            }
+
+            // Benchmark
+            $memBefore = memory_get_usage(true);
+            $start = microtime(true);
+            for ($i = 0; $i < self::ITERATIONS; $i++) {
+                $native();
+            }
+            $nativeTime = (microtime(true) - $start) * 1000; // Convert to milliseconds
+            $nativeMemory = memory_get_usage(true) - $memBefore;
+        }
+
+        // Warmup polyfill
+        for ($i = 0; $i < self::WARMUP_ITERATIONS; $i++) {
+            $polyfill();
+        }
+
+        // Benchmark polyfill
+        $memBefore = memory_get_usage(true);
+        $start = microtime(true);
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
+            $polyfill();
+        }
+        $polyfillTime = (microtime(true) - $start) * 1000; // Convert to milliseconds
+        $polyfillMemory = memory_get_usage(true) - $memBefore;
+
+        $this->printResult($operation, $nativeTime, $polyfillTime, $nativeMemory, $polyfillMemory);
+
+        $this->results[] = [
+            'operation' => $operation,
+            'context' => $context,
+            'native_time' => $nativeTime,
+            'polyfill_time' => $polyfillTime,
+            'native_memory' => $nativeMemory,
+            'polyfill_memory' => $polyfillMemory,
+        ];
+    }
+
+    private function generateNumber(int $digits): string
+    {
+        $number = '';
+        for ($i = 0; $i < $digits; $i++) {
+            $number .= mt_rand(0, 9);
+        }
+        return ltrim($number, '0') ?: '0';
+    }
+
+    private function printHeader(): void
+    {
+        echo "\n";
+        echo "BCMath Performance Benchmark\n";
+        echo "========================================\n";
+        echo "Iterations per test: " . self::ITERATIONS . "\n";
+        echo "Native BCMath: " . ($this->nativeAvailable ? 'Available' : 'Not Available') . "\n";
+        echo "========================================\n\n";
+    }
+
+    private function printSection(string $title): void
+    {
+        echo "\n";
+        echo "$title\n";
+        echo str_repeat('-', strlen($title)) . "\n\n";
+    }
+
+    private function printSubSection(string $title): void
+    {
+        echo "  $title:\n";
+    }
+
+    private function printResult(string $operation, ?float $nativeTime, float $polyfillTime, ?int $nativeMemory, int $polyfillMemory): void
+    {
+        $format = "    %-10s | ";
+        printf($format, $operation);
+
+        if ($this->nativeAvailable && $nativeTime !== null) {
+            printf("Native: %8.3fms (%6s) | ", $nativeTime, $this->formatBytes($nativeMemory));
+            printf("Polyfill: %8.3fms (%6s) | ", $polyfillTime, $this->formatBytes($polyfillMemory));
+
+            $ratio = $polyfillTime / $nativeTime;
+            $slower = $ratio > 1 ? sprintf("%.1fx slower", $ratio) : sprintf("%.1fx faster", 1/$ratio);
+            printf("Ratio: %s", $slower);
+        } else {
+            printf("Polyfill: %8.3fms (%6s)", $polyfillTime, $this->formatBytes($polyfillMemory));
+        }
+
+        echo "\n";
+    }
+
+    private function printSummary(): void
+    {
+        echo "\n";
+        echo "Summary\n";
+        echo "========================================\n";
+
+        if (!$this->nativeAvailable) {
+            echo "Native BCMath extension not available.\n";
+            echo "Only polyfill performance measured.\n";
+            return;
+        }
+
+        $totalNative = 0;
+        $totalPolyfill = 0;
+        $count = 0;
+
+        foreach ($this->results as $result) {
+            if ($result['native_time'] !== null) {
+                $totalNative += $result['native_time'];
+                $totalPolyfill += $result['polyfill_time'];
+                $count++;
+            }
+        }
+
+        if ($count > 0) {
+            $avgRatio = ($totalPolyfill / $totalNative);
+            printf("Average performance ratio: %.2fx\n", $avgRatio);
+
+            if ($avgRatio > 1) {
+                printf("Polyfill is on average %.1fx slower than native\n", $avgRatio);
+            } else {
+                printf("Polyfill is on average %.1fx faster than native\n", 1/$avgRatio);
+            }
+        }
+
+        echo "\n";
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes === 0) return '0B';
+
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $i = floor(log($bytes, 1024));
+
+        return round($bytes / pow(1024, $i), 2) . $units[$i];
+    }
+
+    public function exportResults(string $format = 'json'): string
+    {
+        switch ($format) {
+            case 'json':
+                return json_encode($this->results, JSON_PRETTY_PRINT);
+
+            case 'csv':
+                $csv = "Operation,Native Time (ms),Polyfill Time (ms),Native Memory (bytes),Polyfill Memory (bytes),Ratio\n";
+                foreach ($this->results as $result) {
+                    $ratio = ($result['native_time'] !== null) ? $result['polyfill_time'] / $result['native_time'] : 0;
+                    $csv .= sprintf("%s,%f,%f,%d,%d,%f\n",
+                        $result['operation'],
+                        $result['native_time'] ?? 0,
+                        $result['polyfill_time'],
+                        $result['native_memory'] ?? 0,
+                        $result['polyfill_memory'],
+                        $ratio
+                    );
+                }
+                return $csv;
+
+            case 'markdown':
+                $md = "# BCMath Performance Benchmark Results\n\n";
+                $md .= "| Operation | Context | Native Time | Polyfill Time | Ratio |\n";
+                $md .= "|-----------|---------|-------------|---------------|-------|\n";
+                foreach ($this->results as $result) {
+                    if ($result['native_time'] !== null) {
+                        $ratio = $result['polyfill_time'] / $result['native_time'];
+                        $md .= sprintf("| %s | %s | %.3fms | %.3fms | %.2fx |\n",
+                            $result['operation'],
+                            $result['context'],
+                            $result['native_time'],
+                            $result['polyfill_time'],
+                            $ratio
+                        );
+                    }
+                }
+                return $md;
+
+            default:
+                throw new \InvalidArgumentException("Unsupported format: $format");
+        }
+    }
+}

--- a/benchmarks/run-benchmarks.php
+++ b/benchmarks/run-benchmarks.php
@@ -1,0 +1,66 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use bcmath_compat\Benchmarks\BenchmarkRunner;
+
+// Parse command line arguments
+$options = getopt('f:o:h', ['format:', 'output:', 'help']);
+
+if (isset($options['h']) || isset($options['help'])) {
+    showHelp();
+    exit(0);
+}
+
+$format = $options['f'] ?? $options['format'] ?? null;
+$output = $options['o'] ?? $options['output'] ?? null;
+
+// Create and run benchmark
+$benchmark = new BenchmarkRunner();
+$benchmark->run();
+
+// Export results if requested
+if ($format !== null) {
+    try {
+        $results = $benchmark->exportResults($format);
+
+        if ($output !== null) {
+            file_put_contents($output, $results);
+            echo "\nResults exported to: $output\n";
+        } else {
+            echo "\n" . $results . "\n";
+        }
+    } catch (\InvalidArgumentException $e) {
+        echo "Error: " . $e->getMessage() . "\n";
+        exit(1);
+    }
+}
+
+function showHelp(): void
+{
+    echo <<<HELP
+BCMath Performance Benchmark Tool
+
+Usage: php benchmarks/run-benchmarks.php [OPTIONS]
+
+Options:
+  -f, --format FORMAT   Export results in specified format (json, csv, markdown)
+  -o, --output FILE     Save results to file (instead of stdout)
+  -h, --help           Show this help message
+
+Examples:
+  # Run benchmark with console output only
+  php benchmarks/run-benchmarks.php
+
+  # Export results as JSON
+  php benchmarks/run-benchmarks.php -f json -o results.json
+
+  # Export results as Markdown
+  php benchmarks/run-benchmarks.php -f markdown -o BENCHMARK.md
+
+  # Export results as CSV
+  php benchmarks/run-benchmarks.php -f csv -o results.csv
+
+HELP;
+}

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,16 @@
             "bcmath_compat\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "bcmath_compat\\Benchmarks\\": "benchmarks"
+        }
+    },
     "scripts": {
         "test": "phpunit",
         "check-style": "phpcs src tests",
-        "fix-style": "phpcbf src tests"
+        "fix-style": "phpcbf src tests",
+        "benchmark": "php benchmarks/run-benchmarks.php"
     },
     "provide": {
       "ext-bcmath": "8.1.0"


### PR DESCRIPTION
This pull request introduces a comprehensive benchmarking workflow for the BCMath polyfill project, including new scripts, GitHub Actions workflows, and configuration updates. The main goal is to automate performance benchmarking for both manual and automated scenarios (on PRs and merges), provide easy access to benchmark results, and streamline reporting. The changes are grouped into three main themes: new workflows for benchmarking, a new benchmark runner script, and configuration updates for autoloading and scripts.

**New GitHub Actions workflows for benchmarking:**

* Added `.github/workflows/benchmark-manual.yml` to enable manual triggering of benchmarks, with options for iterations, posting results as PR comments, and support for multiple PHP versions. Results are uploaded as artifacts and can be posted to PRs.
* Added `.github/workflows/benchmark-pr.yml` to automatically run benchmarks on PR events and when a `/benchmark` comment is posted. It posts a summary and partial results as a PR comment, updating the comment on subsequent runs.
* Added `.github/workflows/benchmark-on-merge.yml` to run benchmarks automatically when a PR is merged into `main` and post the results as a comment on the merged PR.

**Benchmark runner script:**

* Added `benchmarks/run-benchmarks.php`, a CLI tool to run benchmarks and export results in various formats (JSON, CSV, Markdown). Supports command-line options for format and output file, and includes a help message.

**Configuration and composer updates:**

* Updated `composer.json` to autoload benchmark classes from the `benchmarks` directory for development, and added a `benchmark` script for easy CLI access to the new runner.

These changes greatly improve the project's benchmarking capabilities, making it easier to track performance regressions and improvements across PHP versions and development branches.