### PR TITLE
refactor(workflows): use file-based approach for comment handling

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -139,7 +139,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const comment = `${{ steps.format_comment.outputs.COMMENT }}`;
+            const fs = require('fs');
+            const comment = fs.readFileSync('comment.md', 'utf8');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/benchmark-on-merge.yml
+++ b/.github/workflows/benchmark-on-merge.yml
@@ -99,7 +99,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const comment = `${{ steps.format.outputs.COMMENT }}`;
+            const fs = require('fs');
+            const comment = fs.readFileSync('comment.md', 'utf8');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -148,14 +148,13 @@ jobs:
           <sub>💡 Comment with `/benchmark` to re-run this test</sub>
           EOL
 
-          echo "COMMENT<<EOF" >> $GITHUB_OUTPUT
-          cat comment.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Save comment to file instead of output variable
+          # to avoid issues with multiline strings
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.number }}
-          body: ${{ steps.format.outputs.COMMENT }}
+          body-path: comment.md
           edit-mode: replace


### PR DESCRIPTION
This pull request updates how benchmark workflow comments are handled in GitHub Actions. The main change is switching from passing multiline comment strings via output variables to reading them from a file (`comment.md`). This approach helps avoid issues with multiline strings in workflow outputs.

**Workflow improvements:**

* In `.github/workflows/benchmark-manual.yml`, the comment is now read from `comment.md` using Node's `fs` module instead of from the output variable.
* In `.github/workflows/benchmark-on-merge.yml`, the comment is also read from `comment.md` via `fs`, replacing the previous output variable method.
* In `.github/workflows/benchmark-pr.yml`, the workflow now uses the `body-path` input to provide the comment from `comment.md` directly, rather than passing it as an output variable, and removes the code that saved the comment to the output variable.