### PR TITLE
fix(RoundingMode): Rector 2.4+ scoped polyfill との class 名衝突を回避

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,6 +22,9 @@ return (new PhpCsFixer\Config())
         '@PhpCsFixer:risky' => true,
         'native_function_invocation' => false,
         'php_unit_test_case_static_method_calls' => false,
+        // Tests verify implicit int/bool→string coercion matching the native bcmath
+        // extension, so enforcing strict types would break intentional compatibility checks.
+        'declare_strict_types' => false,
     ])
     ->setFinder($finder)
 ;

--- a/lib/RoundingMode.php
+++ b/lib/RoundingMode.php
@@ -14,7 +14,7 @@
  *   (e.g. Rector 2.4+ scoped polyfill exposes a class via class_alias)
  */
 // @phpstan-ignore-next-line
-if (!class_exists('\\RoundingMode', false) && !enum_exists('RoundingMode') && version_compare(PHP_VERSION, '8.1', '>=')) {
+if (!class_exists('\RoundingMode', false) && !enum_exists('RoundingMode') && version_compare(PHP_VERSION, '8.1', '>=')) {
     enum RoundingMode: string
     {
         case HalfAwayFromZero = 'half_away_from_zero';

--- a/lib/RoundingMode.php
+++ b/lib/RoundingMode.php
@@ -10,9 +10,11 @@
  * The enum is only defined if:
  * - PHP version is 8.1 or higher (enum support)
  * - Native RoundingMode enum doesn't already exist (PHP < 8.4)
+ * - No class named RoundingMode is already declared in the global namespace
+ *   (e.g. Rector 2.4+ scoped polyfill exposes a class via class_alias)
  */
 // @phpstan-ignore-next-line
-if (!enum_exists('RoundingMode') && version_compare(PHP_VERSION, '8.1', '>=')) {
+if (!class_exists('\\RoundingMode', false) && !enum_exists('RoundingMode') && version_compare(PHP_VERSION, '8.1', '>=')) {
     enum RoundingMode: string
     {
         case HalfAwayFromZero = 'half_away_from_zero';

--- a/lib/RoundingMode.php
+++ b/lib/RoundingMode.php
@@ -9,12 +9,15 @@
  *
  * The enum is only defined if:
  * - PHP version is 8.1 or higher (enum support)
- * - Native RoundingMode enum doesn't already exist (PHP < 8.4)
- * - No class named RoundingMode is already declared in the global namespace
- *   (e.g. Rector 2.4+ scoped polyfill exposes a class via class_alias)
+ * - No class/enum named RoundingMode is already declared in the global namespace.
+ *   Since PHP 8.1 `class_exists()` returns true for enums too, this single check
+ *   covers both the native PHP 8.4+ RoundingMode enum and the Rector 2.4+
+ *   scoped polyfill that exposes a class via class_alias.
  */
-// @phpstan-ignore-next-line
-if (!class_exists('\RoundingMode', false) && !enum_exists('RoundingMode') && version_compare(PHP_VERSION, '8.1', '>=')) {
+// The version_compare check is defensive runtime safety. composer.json constrains
+// PHP to >=8.1, so PHPStan always infers this as always-true; silence that.
+// @phpstan-ignore-next-line booleanAnd.rightAlwaysTrue
+if (!class_exists('RoundingMode', false) && version_compare(PHP_VERSION, '8.1', '>=')) {
     enum RoundingMode: string
     {
         case HalfAwayFromZero = 'half_away_from_zero';

--- a/lib/bcmath.php
+++ b/lib/bcmath.php
@@ -88,9 +88,9 @@ if (!function_exists('bcadd')) {
      *
      * @param null|int $scale optional
      */
-    function bcpow(string $base, string $exponent, ?int $scale = null): string
+    function bcpow(string $num, string $exponent, ?int $scale = null): string
     {
-        return BCMath::pow($base, $exponent, $scale);
+        return BCMath::pow($num, $exponent, $scale);
     }
 
     /**
@@ -98,9 +98,9 @@ if (!function_exists('bcadd')) {
      *
      * @param null|int $scale optional
      */
-    function bcpowmod(string $base, string $exponent, string $modulus, ?int $scale = null): string
+    function bcpowmod(string $num, string $exponent, string $modulus, ?int $scale = null): string
     {
-        return BCMath::powmod($base, $exponent, $modulus, $scale);
+        return BCMath::powmod($num, $exponent, $modulus, $scale);
     }
 
     /**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,42 @@ parameters:
 		-
 			identifier: expr.resultUnused
 			path: tests/BCMathWithoutExtensionTest.php
+		# Rector 2.4+ ships a scoped polyfill at
+		# vendor/rector/rector/vendor/symfony/polyfill-php84/Resources/RoundingMode.php
+		# that registers a global `class RoundingMode` with string constants
+		# (e.g. HalfAwayFromZero = 'halfawayfromzero') via class_alias. PHPStan's
+		# Better Reflection walks vendor recursively and binds `\RoundingMode` to
+		# that class instead of our enum polyfill in lib/RoundingMode.php, so
+		# references to `\RoundingMode::HalfAwayFromZero` are typed as string
+		# rather than as an enum case. At runtime the enum in lib/RoundingMode.php
+		# wins because it is loaded via composer files autoload before Rector's
+		# autoload has any chance to run for the global name (and our tests
+		# confirm the enum is the one in use). These errors are purely a
+		# static-analysis artifact. See https://github.com/nanasess/bcmath-polyfill/issues/56
+		-
+			identifier: match.alwaysFalse
+			path: src/BCMath.php
+			message: "#Match arm comparison between RoundingMode and '(halfawayfromzero|halftowardszero|halfeven|halfodd|towardszero|awayfromzero|negativeinfinity|positiveinfinity)' is always false\\.#"
+		-
+			identifier: argument.type
+			message: "#Parameter \\#3 \\$mode of (static method bcmath_compat\\\\BCMath::round\\(\\)|function bcround) expects int\\|RoundingMode, (string|int) given\\.#"
+			paths:
+				- src/BCMath.php
+				- tests/BCMathTest.php
+				- tests/BCMathWithoutExtensionTest.php
+		-
+			identifier: return.type
+			path: tests/BCMathTest.php
+			message: "#Method BCMathTest::provideRoundingModeEnumSupportCases\\(\\).*RoundingMode.*#"
+		-
+			identifier: function.impossibleType
+			path: tests/BCMathTest.php
+			message: "#Call to function in_array\\(\\) with arguments RoundingMode, array\\{.*\\} and true will always evaluate to false\\.#"
+		-
+			identifier: encapsedStringPart.nonString
+			path: tests/BCMathTest.php
+			message: "#Part \\$\\w+->name \\(mixed\\) of encapsed string cannot be cast to string\\.#"
+		-
+			identifier: property.nonObject
+			path: tests/BCMathTest.php
+			message: "#Cannot access property \\$name on string\\.#"

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -16,5 +17,8 @@ return RectorConfig::configure()
     ->withPreparedSets(typeDeclarations: true, deadCode: true, codeQuality: true)
     ->withSkip([
         UnwrapFutureCompatibleIfPhpVersionRector::class,
+        // Tests rely on implicit int/bool→string coercion to verify native bcmath
+        // extension compatibility; declaring strict types would break them.
+        SafeDeclareStrictTypesRector::class,
         __DIR__ . '/tests/php-src',
     ]);

--- a/src/BCMath.php
+++ b/src/BCMath.php
@@ -631,7 +631,7 @@ abstract class BCMath
     public static function pow(string $base, string $exponent, ?int $scale = null): string
     {
         // Phase 1: Argument validation
-        self::validateNumberString($base, 'bcpow', 1, 'base');
+        self::validateNumberString($base, 'bcpow', 1, 'num');
         self::validateNumberString($exponent, 'bcpow', 2, 'exponent');
 
         // Phase 2: Scale resolution and validation
@@ -743,7 +743,7 @@ abstract class BCMath
             throw new \ArgumentCountError('bcpowmod() expects at most 4 arguments, '.func_num_args().' given');
         }
 
-        self::validateNumberString($base, 'bcpowmod', 1, 'base');
+        self::validateNumberString($base, 'bcpowmod', 1, 'num');
         self::validateNumberString($exponent, 'bcpowmod', 2, 'exponent');
         self::validateNumberString($modulus, 'bcpowmod', 3, 'modulus');
 

--- a/tests/RoundingModeGuardTest.php
+++ b/tests/RoundingModeGuardTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class RoundingModeGuardTest extends TestCase
+{
+    /**
+     * Regression test for issue #56.
+     *
+     * Rector 2.4.x's scoped polyfill declares a global `class RoundingMode`
+     * via `class_alias` on PHP < 8.4. The polyfill in lib/RoundingMode.php
+     * must detect this and skip enum declaration.
+     */
+    #[RequiresPhp('< 8.4')]
+    public function testPolyfillSkipsWhenRoundingModeClassAlreadyDefined(): void
+    {
+        $result = $this->runFixture(__DIR__ . '/fixtures/rector-scenario.php');
+
+        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: ' . $result['stderr']);
+        $this->assertStringNotContainsString('Cannot declare enum', $result['stderr']);
+        $this->assertStringNotContainsString('Fatal error', $result['stderr']);
+        $this->assertStringContainsString('OK', $result['stdout']);
+    }
+
+    #[RequiresPhp('>= 8.1 < 8.4')]
+    public function testPolyfillDefinesEnumOnCleanLoad(): void
+    {
+        $result = $this->runFixture(__DIR__ . '/fixtures/clean-load.php');
+
+        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: ' . $result['stderr']);
+        $this->assertStringContainsString('ENUM_DEFINED', $result['stdout']);
+    }
+
+    /**
+     * @return array{stdout: string, stderr: string, exitCode: int}
+     */
+    private function runFixture(string $fixturePath): array
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open([PHP_BINARY, $fixturePath], $descriptors, $pipes);
+        if (!is_resource($process)) {
+            $this->fail('Failed to spawn PHP subprocess');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        return [
+            'stdout' => $stdout === false ? '' : $stdout,
+            'stderr' => $stderr === false ? '' : $stderr,
+            'exitCode' => $exitCode,
+        ];
+    }
+}

--- a/tests/RoundingModeGuardTest.php
+++ b/tests/RoundingModeGuardTest.php
@@ -20,9 +20,9 @@ final class RoundingModeGuardTest extends TestCase
     #[RequiresPhp('< 8.4')]
     public function testPolyfillSkipsWhenRoundingModeClassAlreadyDefined(): void
     {
-        $result = $this->runFixture(__DIR__ . '/fixtures/rector-scenario.php');
+        $result = $this->runFixture(__DIR__.'/fixtures/rector-scenario.php');
 
-        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: ' . $result['stderr']);
+        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: '.$result['stderr']);
         $this->assertStringNotContainsString('Cannot declare enum', $result['stderr']);
         $this->assertStringNotContainsString('Fatal error', $result['stderr']);
         $this->assertStringContainsString('OK', $result['stdout']);
@@ -31,9 +31,9 @@ final class RoundingModeGuardTest extends TestCase
     #[RequiresPhp('>= 8.1 < 8.4')]
     public function testPolyfillDefinesEnumOnCleanLoad(): void
     {
-        $result = $this->runFixture(__DIR__ . '/fixtures/clean-load.php');
+        $result = $this->runFixture(__DIR__.'/fixtures/clean-load.php');
 
-        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: ' . $result['stderr']);
+        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: '.$result['stderr']);
         $this->assertStringContainsString('ENUM_DEFINED', $result['stdout']);
     }
 

--- a/tests/RoundingModeGuardTest.php
+++ b/tests/RoundingModeGuardTest.php
@@ -17,7 +17,7 @@ final class RoundingModeGuardTest extends TestCase
      * via `class_alias` on PHP < 8.4. The polyfill in lib/RoundingMode.php
      * must detect this and skip enum declaration.
      */
-    #[RequiresPhp('< 8.4')]
+    #[RequiresPhp('>= 8.1 < 8.4')]
     public function testPolyfillSkipsWhenRoundingModeClassAlreadyDefined(): void
     {
         $result = $this->runFixture(__DIR__.'/fixtures/rector-scenario.php');

--- a/tests/RoundingModeGuardTest.php
+++ b/tests/RoundingModeGuardTest.php
@@ -75,6 +75,7 @@ final class RoundingModeGuardTest extends TestCase
 
         $stdout = '';
         $stderr = '';
+        $exitCode = -1;
         $deadline = microtime(true) + $timeoutSeconds;
 
         while (true) {
@@ -89,6 +90,9 @@ final class RoundingModeGuardTest extends TestCase
 
             $status = proc_get_status($process);
             if (!$status['running']) {
+                // Capture exit code from status: on PHP < 8.3 calling proc_get_status()
+                // reaps the process so the subsequent proc_close() returns -1.
+                $exitCode = $status['exitcode'];
                 // Drain any remaining buffered output after the process exited.
                 $chunkOut = stream_get_contents($pipes[1]);
                 if ($chunkOut !== false) {
@@ -115,7 +119,7 @@ final class RoundingModeGuardTest extends TestCase
 
         fclose($pipes[1]);
         fclose($pipes[2]);
-        $exitCode = proc_close($process);
+        proc_close($process);
 
         return [
             'stdout' => $stdout,

--- a/tests/RoundingModeGuardTest.php
+++ b/tests/RoundingModeGuardTest.php
@@ -38,9 +38,25 @@ final class RoundingModeGuardTest extends TestCase
     }
 
     /**
+     * On PHP 8.4+ the native RoundingMode enum is already registered, so the polyfill
+     * guard in lib/RoundingMode.php must short-circuit. This asserts that loading the
+     * polyfill produces no fatal, and that the (native) enum is visible afterwards.
+     */
+    #[RequiresPhp('>= 8.4')]
+    public function testPolyfillSkipsOnPhp84WithNativeEnum(): void
+    {
+        $result = $this->runFixture(__DIR__.'/fixtures/clean-load.php');
+
+        $this->assertSame(0, $result['exitCode'], 'Fixture exited with non-zero status. stderr: '.$result['stderr']);
+        $this->assertStringNotContainsString('Cannot declare enum', $result['stderr']);
+        $this->assertStringNotContainsString('Fatal error', $result['stderr']);
+        $this->assertStringContainsString('ENUM_DEFINED', $result['stdout']);
+    }
+
+    /**
      * @return array{stdout: string, stderr: string, exitCode: int}
      */
-    private function runFixture(string $fixturePath): array
+    private function runFixture(string $fixturePath, int $timeoutSeconds = 10): array
     {
         $descriptors = [
             0 => ['pipe', 'r'],
@@ -54,16 +70,56 @@ final class RoundingModeGuardTest extends TestCase
         }
 
         fclose($pipes[0]);
-        $stdout = stream_get_contents($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+
+        $stdout = '';
+        $stderr = '';
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        while (true) {
+            $chunkOut = stream_get_contents($pipes[1]);
+            if ($chunkOut !== false) {
+                $stdout .= $chunkOut;
+            }
+            $chunkErr = stream_get_contents($pipes[2]);
+            if ($chunkErr !== false) {
+                $stderr .= $chunkErr;
+            }
+
+            $status = proc_get_status($process);
+            if (!$status['running']) {
+                // Drain any remaining buffered output after the process exited.
+                $chunkOut = stream_get_contents($pipes[1]);
+                if ($chunkOut !== false) {
+                    $stdout .= $chunkOut;
+                }
+                $chunkErr = stream_get_contents($pipes[2]);
+                if ($chunkErr !== false) {
+                    $stderr .= $chunkErr;
+                }
+
+                break;
+            }
+
+            if (microtime(true) > $deadline) {
+                proc_terminate($process);
+                fclose($pipes[1]);
+                fclose($pipes[2]);
+                proc_close($process);
+                $this->fail(sprintf('Subprocess for %s timed out after %ds. stderr so far: %s', $fixturePath, $timeoutSeconds, $stderr));
+            }
+
+            usleep(10000);
+        }
+
         fclose($pipes[1]);
         fclose($pipes[2]);
-
         $exitCode = proc_close($process);
 
         return [
-            'stdout' => $stdout === false ? '' : $stdout,
-            'stderr' => $stderr === false ? '' : $stderr,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
             'exitCode' => $exitCode,
         ];
     }

--- a/tests/fixtures/clean-load.php
+++ b/tests/fixtures/clean-load.php
@@ -7,6 +7,6 @@
  * symbol and verifies the polyfill enum is declared as expected on
  * PHP 8.1-8.3.
  */
-require __DIR__ . '/../../lib/RoundingMode.php';
+require __DIR__.'/../../lib/RoundingMode.php';
 
 echo enum_exists('RoundingMode') ? "ENUM_DEFINED\n" : "ENUM_MISSING\n";

--- a/tests/fixtures/clean-load.php
+++ b/tests/fixtures/clean-load.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Baseline fixture for issue #56 regression tests.
+ *
+ * Loads lib/RoundingMode.php without any pre-existing `RoundingMode`
+ * symbol and verifies the polyfill enum is declared as expected on
+ * PHP 8.1-8.3.
+ */
+require __DIR__ . '/../../lib/RoundingMode.php';
+
+echo enum_exists('RoundingMode') ? "ENUM_DEFINED\n" : "ENUM_MISSING\n";

--- a/tests/fixtures/rector-scenario.php
+++ b/tests/fixtures/rector-scenario.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Reproduction fixture for issue #56.
+ *
+ * Simulates Rector 2.4.x's scoped polyfill that pre-declares a global
+ * `class RoundingMode` via `class_alias`, and then loads this package's
+ * RoundingMode polyfill. The guard in lib/RoundingMode.php must skip
+ * enum declaration to avoid a "Cannot declare enum" fatal error.
+ */
+class RoundingMode
+{
+    public const HalfAwayFromZero = 'halfawayfromzero';
+    public const HalfTowardsZero = 'halftowardszero';
+    public const HalfEven = 'halfeven';
+    public const HalfOdd = 'halfodd';
+    public const TowardsZero = 'towardszero';
+    public const AwayFromZero = 'awayfromzero';
+    public const NegativeInfinity = 'negativeinfinity';
+    public const PositiveInfinity = 'positiveinfinity';
+}
+
+require __DIR__ . '/../../lib/RoundingMode.php';
+
+echo "OK\n";

--- a/tests/fixtures/rector-scenario.php
+++ b/tests/fixtures/rector-scenario.php
@@ -20,6 +20,6 @@ class RoundingMode
     public const PositiveInfinity = 'positiveinfinity';
 }
 
-require __DIR__ . '/../../lib/RoundingMode.php';
+require __DIR__.'/../../lib/RoundingMode.php';
 
 echo "OK\n";


### PR DESCRIPTION
## 概要

Issue #56 の修正。`nanasess/bcmath-polyfill` の `lib/RoundingMode.php` は PHP 8.1-8.3 向けに `enum RoundingMode` を定義する polyfill だが、Rector 2.4.0 以降が scoped polyfill (`symfony/polyfill-php84`) で `class_alias` を使ってグローバル名前空間に `class RoundingMode` を先行定義すると、既存のガード (`!enum_exists('RoundingMode')`) では検出できず **"Cannot declare enum RoundingMode" fatal error** が発生していた。

## 変更内容

- **`lib/RoundingMode.php`**: ガード条件に `!class_exists('\\RoundingMode', false)` を追加。autoload を trigger しないため `symfony/polyfill-php84` の stub 呼び出しを引き起こさない。docblock にも条件を追記。
- **`tests/RoundingModeGuardTest.php`** (新規): `proc_open` で独立した PHP サブプロセスを起動し、Rector シナリオの再現とクリーンロード時の回帰を検証する PHPUnit テスト。Composer の files autoload が PHPUnit 起動時に polyfill を先に実行してしまうため、サブプロセスで「class 先行定義 → polyfill 読み込み」の順序を再現する必要がある。
- **`tests/fixtures/rector-scenario.php`** / **`tests/fixtures/clean-load.php`** (新規): 上記テスト用 fixture。

## 影響範囲

`rector/rector: ^2.4` を dev-require している本パッケージの利用プロジェクト全般 (PHP 8.3 以下)。Rector 2.3.x 以下では未発生。

## Test plan

- [x] PHP 8.3 (docker `ghcr.io/ec-cube/ec-cube-php:8.3-apache`) で新規テストが通ること
- [x] PHP 8.3 で修正を revert するとテストが "Cannot declare enum" で落ちること (回帰防止が機能)
- [x] PHP 8.5 (local) の全既存テスト 274 件が回帰なしに通ること
- [x] PHPStan で新規・修正ファイルにエラーが出ないこと
- [x] PHP-CS-Fixer で新規・修正ファイルが style 違反なしで通ること
- [x] 手動再現: `php -r 'class RoundingMode { const HalfAwayFromZero = "halfawayfromzero"; } require "lib/RoundingMode.php"; echo "OK\n";'` が修正後は `OK` を出力
- [ ] CI マトリクス (PHP 8.1-8.5 × 3 OS) が全通過すること

## Related issues

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ポリフィルの読み込みガードを改善し、既存のグローバルシンボルと競合しないようにしました。

* **テスト**
  * ポリフィルの動作を検証する回帰テストと実行フィクスチャを追加しました。

* **その他**
  * 一部公開関数のパラメータ名と内部エラーメッセージ表現を調整しました（互換性に影響なし）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->