### PR TITLE
ci: GitHub Actions を commit SHA でピン固定（サプライチェーン対策）

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: bcmath
@@ -87,7 +87,7 @@ jobs:
           echo "performance_ratio=$RATIO" >> $GITHUB_OUTPUT
 
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-results-php${{ matrix.php-version }}
           path: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Post results to PR
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.post_comment == 'true' && github.event.inputs.pr_number
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/benchmark-on-merge.yml
+++ b/.github/workflows/benchmark-on-merge.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.2'
           extensions: bcmath
@@ -96,7 +96,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post benchmark results to PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Checkout the PR branch for pull_request events
           # For issue_comment events, checkout the PR's head
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch PR details for comment trigger
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: pr_details
         with:
           script: |
@@ -60,12 +60,12 @@ jobs:
 
       - name: Checkout PR for comment trigger
         if: github.event_name == 'issue_comment'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.pr_details.outputs.head_sha }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.2'
           extensions: bcmath
@@ -97,7 +97,7 @@ jobs:
           echo "performance_ratio=$RATIO" >> $GITHUB_OUTPUT
 
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
           issue-number: ${{ steps.pr.outputs.number }}
@@ -152,7 +152,7 @@ jobs:
           # to avoid issues with multiline strings
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             -   name: Install dependencies
-                uses: php-actions/composer@v6
+                uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
                 with:
                     php_version: '8.1'
             -   name: Run PHP-CS-Fixer
@@ -24,13 +24,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             -   name: Install dependencies
-                uses: php-actions/composer@v6
+                uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
                 with:
                     php_version: '8.1'
             -   name: Run PHPStan
-                uses: php-actions/phpstan@v3
+                uses: php-actions/phpstan@d8f8887acaac249b05ac11909c4cdbb018f52211 # v3
                 with:
                     php_version: '8.1'
 
@@ -41,9 +41,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
                 with:
                     php-version: ${{ matrix.php-version }}
             -   name: Composer Install
@@ -63,9 +63,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
                 with:
                     php-version: ${{ matrix.php-version }}
                     extensions: :bcmath # ubuntu only
@@ -85,9 +85,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             -   name: Checkout php-src repository
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
                 with:
                     repository: php/php-src
                     path: php-src

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,13 +29,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -11,25 +11,25 @@ jobs:
         steps:
             -
                 if: github.event.pull_request.head.repo.full_name == github.repository
-                uses: actions/checkout@v5
+                uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}
 
             -
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
                 with:
                     php-version: 8.1
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v3"
+            -   uses: "ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f" # v3
 
             -   run: vendor/bin/rector --ansi
             # @todo apply coding standard if used
 
             -
                 # commit only to core contributors who have repository access
-                uses: stefanzweifel/git-auto-commit-action@v6
+                uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
                 with:
                     commit_message: '[rector] Rector fixes'
                     commit_author: 'GitHub Action <actions@github.com>'


### PR DESCRIPTION
## 概要

GitHub Actions のアクション参照を可変タグ（`@v5` 等）から不変の **commit SHA** に固定しました。タグは付け替え可能なため、悪意あるコード差し替え（サプライチェーン攻撃）のリスクがあります。SHA ピンにより、参照先のコードが固定されます。

## 変更内容

- `.github/workflows/` 配下 **7ファイル・全28箇所** の `uses:` を commit SHA に固定
- 各行に可読性のためのバージョンコメント（`# v5` 等）を付与
- **Dependabot** は「SHA + バージョンコメント」形式を自動認識し、以後も SHA を最新へ更新するため `dependabot.yml` の変更は不要

### ピンしたアクション一覧

| アクション | バージョン | SHA |
|---|---|---|
| actions/checkout | v5 | `93cb6ef` |
| actions/checkout | v4 | `34e1148` |
| anthropics/claude-code-action | v1 | `787c5a0` |
| php-actions/composer | v6 | `8a65f0d` |
| php-actions/phpstan | v3 | `d8f8887` |
| shivammathur/setup-php | v2 | `7c071df` |
| actions/github-script | v8 | `ed59741` |
| actions/upload-artifact | v4 | `ea165f8` |
| ramsey/composer-install | v3 | `a8d0d95` |
| stefanzweifel/git-auto-commit-action | v6 | `778341a` |
| peter-evans/find-comment | v3 | `3eae4d3` |
| peter-evans/create-or-update-comment | v5 | `e8674b0` |

## 検証

- [x] 残存タグ参照（`@vN`）がゼロであることを確認
- [x] 全7ファイルが YAML として正常にパースできることを確認
- [x] diff が `uses:` 行のみであることを確認（非 `uses:` 変更は0件）

## 補足

- `checkout` の `v4`/`v5` 混在は現状維持（バージョン統一は別タスク）
- `ramsey/composer-install@v3` は branch 参照のため、最新 3.x（3.2.1）の commit SHA に固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフロー内で使用する外部アクションの参照を、バージョンタグから特定のコミットハッシュに固定しました。セキュリティとビルドの再現性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 追記: Dependabot の phpunit メジャー更新を無視

Dependabot の composer 更新ログで以下のエラーが毎週記録されていた問題に対応:

```
Your requirements could not be resolved to an installable set of packages.
  - Root composer.json requires phpunit/phpunit >= 10.5, == 13.1.13
  - phpunit/phpunit 13.1.13 requires php >=8.4.1 -> your php version (8.1) does not satisfy that requirement.
```

本ライブラリは PHP 8.1+ をサポートするため、PHP 8.4+ を要求する phpunit 13 系へは更新できない(phpunit 11=PHP8.2 / 12=8.3 / 13=8.4)。これは正しい挙動だが Dependabot が毎回解決失敗エラーを出すため、`dependabot.yml` に phpunit のメジャー更新を無視する `ignore` ルールを追加した。

> Job 自体は success であり CI を失敗させてはいなかったが、ログのノイズを解消する目的。