### PR TITLE
ci: Dependabot で phpunit のメジャー更新を無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    ignore:
+      # PHP 8.1 サポート維持のため phpunit はメジャー更新しない
+      # (phpunit 11=PHP8.2, 12=8.3, 13=8.4 を要求するため)
+      - dependency-name: "phpunit/phpunit"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## 概要

Dependabot の composer 更新ログで毎週以下のエラーが記録されていた問題に対応します。

```
Your requirements could not be resolved to an installable set of packages.
  - Root composer.json requires phpunit/phpunit >= 10.5, == 13.1.13
  - phpunit/phpunit 13.1.13 requires php >=8.4.1 -> your php version (8.1) does not satisfy that requirement.
```

## 原因

本ライブラリは PHP 8.1+ をサポートするため `require.php` が `>=8.1`。一方 phpunit はメジャーごとに必要 PHP が上がる(11=PHP8.2 / 12=8.3 / 13=8.4)ため、PHP 8.1 を維持したまま phpunit 13 へ更新することは不可能。Dependabot が解決時に PHP 下限(8.1)を採用するため、毎回解決失敗エラーを出していた。

> Job 自体は success であり CI を失敗させてはいなかったが、ログのノイズを解消する目的。

## 変更内容

`dependabot.yml` の composer セクションに、phpunit のメジャー更新を無視する `ignore` ルールを追加。

- phpunit のマイナー/パッチ更新(10.x 系内)は引き続き提案される(セキュリティ修正は取りこぼさない)
- PHP 8.1 サポート方針を設定として明文化

## 補足

当初 SHA ピン PR (#59) に含めていたが、#59 が先にマージされたため、本コミットを単独 PR として切り出した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 依存関係管理設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->