### PR TITLE
fix: resolve PHPStan booleanAnd.leftAlwaysTrue in RoundingMode test

### DIFF
--- a/tests/BCMathTest.php
+++ b/tests/BCMathTest.php
@@ -2025,8 +2025,10 @@ final class BCMathTest extends TestCase
         ];
 
         foreach ($expectedCases as $caseName) {
+            // enum_exists('RoundingMode') は冒頭の markTestSkipped ガードで true 確定済みのため、
+            // ここでは defined() のみ検証する（PHPStan の booleanAnd.leftAlwaysTrue 回避）。
             $this->assertTrue(
-                enum_exists('RoundingMode') && defined("RoundingMode::{$caseName}"),
+                defined("RoundingMode::{$caseName}"),
                 "RoundingMode::{$caseName} should be available"
             );
         }


### PR DESCRIPTION
## Summary

After the PHPStan upgrade (improved type narrowing in 2.x), `tests/BCMathTest.php` started failing with:

```
tests/BCMathTest.php:2029  Left side of && is always true.  (booleanAnd.leftAlwaysTrue)
Found 1 error
```

## Cause

`testRoundingModeEnvironmentDetection()` has an early skip guard at the top:

```php
if (!enum_exists('RoundingMode')) {
    $this->markTestSkipped('RoundingMode enum not available');
}
```

Once this guard is passed, PHPStan narrows the type to `enum_exists('RoundingMode') === true`. As a result, the left side of `assertTrue(enum_exists('RoundingMode') && defined(...))` is considered always true. This is not a real bug — it surfaces a redundant duplicate check now that the newer PHPStan narrows the return value of `enum_exists()`.

## Fix

Removed the redundant `enum_exists('RoundingMode') &&` from the `assertTrue` call and now verify only `defined()`. The intent is documented in a comment.

## Verification

- `php -d memory_limit=1G vendor/bin/phpstan analyse` — the 2029 error is gone (the 4 `bcround` errors that appear locally are an environment difference caused by the absence of the rector polyfill; they do not occur in CI, as confirmed by the CI log showing `Found 1 error`)
- `vendor/bin/phpunit --filter testRoundingModeEnvironmentDetection` — OK (1 test, 8 assertions)
- `vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes` — Found 0 of 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)