### PR TITLE
ci: skip claude-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # Skip on Dependabot PRs: such PRs may modify this workflow file (e.g. bumping
+    # the actions/checkout SHA), which makes claude-code-action's OIDC token exchange
+    # fail with "Workflow validation failed" because the workflow no longer matches the
+    # version on the default branch. Skipping avoids that expected, unavoidable failure.
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

Skip the `claude-review` job on Dependabot PRs by adding `if: github.actor != 'dependabot[bot]'`.

## Background

When Dependabot opens a PR that modifies a workflow file — for example bumping the `actions/checkout` SHA inside `.github/workflows/claude-code-review.yml` (see #67) — the `claude-review` job fails during the OIDC → App token exchange:

```
App token exchange failed: 401 Unauthorized - Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
```

`anthropics/claude-code-action` validates that the workflow file running in the PR is byte-for-byte identical to the version on the default branch. Because a Dependabot PR changes that very file, the content no longer matches `main`, so the exchange returns 401. The action itself notes this is expected:

> If you're seeing this on a PR ... this is normal and you should ignore this error.

This is an unavoidable, structural failure for any PR that edits the workflow file, not a code or secret problem.

## Change

Add `if: github.actor != 'dependabot[bot]'` to the `claude-review` job so it is skipped on Dependabot PRs, avoiding the noisy red check. Human-authored PRs are unaffected and still get the review.

## Note

This PR also edits `claude-code-review.yml`, so its own `claude-review` run will fail with the same validation error until merged. That is expected; once merged the workflow on `main` matches and subsequent (non-Dependabot) PRs validate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)