### PR TITLE
ci: detect Dependabot PRs via PR author, not github.actor

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,12 @@ jobs:
     # the actions/checkout SHA), which makes claude-code-action's OIDC token exchange
     # fail with "Workflow validation failed" because the workflow no longer matches the
     # version on the default branch. Skipping avoids that expected, unavoidable failure.
-    if: github.actor != 'dependabot[bot]'
+    #
+    # Use the PR author (pull_request.user.login), NOT github.actor: github.actor is
+    # whoever triggered the run, so when merging another PR causes Dependabot to rebase
+    # this one, the run is attributed to the human merger and the check would not be
+    # skipped. The PR author stays 'dependabot[bot]' regardless of who triggers the run.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     # Optional: Filter by PR author
     # if: |


### PR DESCRIPTION
## Summary

Fix the Dependabot skip condition on the `claude-review` job. The previous condition added in #69 — `if: github.actor != 'dependabot[bot]'` — did not actually skip the job on Dependabot PRs.

## Why the previous fix did not work

Observed on PR #67: after #69 was merged, the `claude-review` run still failed instead of being skipped.

`github.actor` is **whoever triggered the run**, not the PR author. Merging #69 into `main` caused Dependabot to automatically rebase #67, which fired a `synchronize` event — but because that rebase was triggered by the human merge, GitHub attributed the run's `github.actor` / `triggering_actor` to `nanasess`, not `dependabot[bot]`. So `'nanasess' != 'dependabot[bot]'` evaluated to `true`, the job ran (not skipped), and failed the workflow-file validation with 401 as before.

## Fix

Use the PR author, which stays `dependabot[bot]` regardless of who triggers the run:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

A comment explaining the `github.actor` pitfall is included so it is not "fixed back" later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub ActionsワークフローのDependabotプルリクエスト検出ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->