### PR TITLE
fix(ci): PHPStan / macOS setup-php / Docker PHPT の CI 失敗修正 + bcround OOM 修正

### DIFF
--- a/.github/workflows/benchmark-manual.yml
+++ b/.github/workflows/benchmark-manual.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: bcmath

--- a/.github/workflows/benchmark-on-merge.yml
+++ b/.github/workflows/benchmark-on-merge.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
           extensions: bcmath

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -65,7 +65,7 @@ jobs:
           ref: ${{ steps.pr_details.outputs.head_sha }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
           extensions: bcmath

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             -   name: Setup PHP
-                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
                 with:
                     php-version: ${{ matrix.php-version }}
             -   name: Composer Install
@@ -65,7 +65,7 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             -   name: Setup PHP
-                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
                 with:
                     php-version: ${{ matrix.php-version }}
                     extensions: :bcmath # ubuntu only
@@ -97,7 +97,8 @@ jobs:
                 run: |
                   # scale_ini test skipped: bcmath.scale INI setting ignored without native extension
                   # gh20006 test skipped: requires BcMath\Number OOP API (not supported by polyfill)
-                  docker run --rm -v $PWD:/app bcmath-phpt-test:${{ matrix.php-version }} --skip bcdivmod,bug54598,bug72093,bug75178,gh15968,gh16262,scale_ini,bcmul_check_overflow,bug78878,bcpow_error1,bcpow_error2,bcpow_error3,bcpowmod_error,bcpowmod_with_mod_1,bcpowmod_zero_modulus,bcround_all,bcround_away_from_zero,bcround_ceiling,bcround_early_return,bcround_floor,bcround_toward_zero,bcscale_variation003,bcdivmod_by_zero,gh20006
+                  # bcround_precision_bounds test skipped: requires BcMath\Number OOP API (not supported by polyfill)
+                  docker run --rm -v $PWD:/app bcmath-phpt-test:${{ matrix.php-version }} --skip bcdivmod,bug54598,bug72093,bug75178,gh15968,gh16262,scale_ini,bcmul_check_overflow,bug78878,bcpow_error1,bcpow_error2,bcpow_error3,bcpowmod_error,bcpowmod_with_mod_1,bcpowmod_zero_modulus,bcround_all,bcround_away_from_zero,bcround_ceiling,bcround_early_return,bcround_floor,bcround_toward_zero,bcscale_variation003,bcdivmod_by_zero,gh20006,bcround_precision_bounds
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -17,7 +17,7 @@ jobs:
                     token: ${{ secrets.ACCESS_TOKEN }}
 
             -
-                uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
                 with:
                     php-version: 8.1
                     coverage: none

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,6 +42,17 @@ parameters:
 			identifier: function.impossibleType
 			path: tests/BCMathTest.php
 			message: "#Call to function in_array\\(\\) with arguments RoundingMode, array\\{.*\\} and true will always evaluate to false\\.#"
+		# PHPStan binds `\RoundingMode` to Rector's scoped polyfill class (not an
+		# enum), so `enum_exists('RoundingMode')` is statically inferred as always
+		# false. At runtime our enum polyfill in lib/RoundingMode.php is the one in
+		# use, so these guards are legitimate. Same static-analysis artifact as above.
+		-
+			identifier: function.impossibleType
+			message: "#Call to function enum_exists\\(\\) with 'RoundingMode' will always evaluate to false\\.#"
+			paths:
+				- src/BCMath.php
+				- tests/BCMathTest.php
+				- tests/fixtures/clean-load.php
 		-
 			identifier: encapsedStringPart.nonString
 			path: tests/BCMathTest.php

--- a/src/BCMath.php
+++ b/src/BCMath.php
@@ -1012,6 +1012,16 @@ abstract class BCMath
      */
     public static function round(string $num, int $precision = 0, $mode = PHP_ROUND_HALF_UP): string
     {
+        // PHP's native bcround() (8.4+) rejects a $precision above INT_MAX before
+        // performing any computation. Without this guard a huge precision triggers
+        // an out-of-memory fatal via str_repeat() in bcroundHelper(). Mirror
+        // php-src's bcmath_check_precision(): only the upper bound overflows int.
+        if ($precision > 2147483647) {
+            throw new \ValueError(
+                'bcround(): Argument #2 ($precision) must be between '.PHP_INT_MIN.' and 2147483647'
+            );
+        }
+
         self::validateNumberString($num, 'bcround', 1, 'num');
 
         if (!is_numeric($num)) {

--- a/tests/BCMathTest.php
+++ b/tests/BCMathTest.php
@@ -827,6 +827,43 @@ final class BCMathTest extends TestCase
     }
 
     /**
+     * bcround() must reject a $precision above INT_MAX with a ValueError,
+     * mirroring PHP 8.4's native behaviour. Previously such values triggered
+     * an out-of-memory fatal via str_repeat() (php-src bcround_precision_bounds).
+     */
+    public function testRoundPrecisionAboveIntMaxThrows(): void
+    {
+        if (PHP_INT_SIZE !== 8) {
+            $this->markTestSkipped('Requires a 64-bit platform where PHP_INT_MAX exceeds INT_MAX.');
+        }
+
+        $expectedMessage = 'bcround(): Argument #2 ($precision) must be between '.PHP_INT_MIN.' and 2147483647';
+
+        foreach ([PHP_INT_MAX, 2147483648] as $precision) {
+            $caught = null;
+
+            try {
+                BCMath::round('1', $precision);
+            } catch (\ValueError $e) {
+                $caught = $e;
+            }
+            $this->assertInstanceOf(
+                \ValueError::class,
+                $caught,
+                "Expected ValueError for precision={$precision}"
+            );
+            $this->assertSame($expectedMessage, $caught->getMessage());
+        }
+
+        // Note: we intentionally do not cross-check against the native bcround(),
+        // because the precision bounds guard is a php-src master (8.6) addition and
+        // released bcmath (e.g. 8.5) still OOMs on such precision values.
+
+        // A normal in-range precision must still work and not be over-rejected.
+        $this->assertSame('1.00', BCMath::round('1', 2));
+    }
+
+    /**
      * Test sqrt bug reproduction cases.
      *
      * This test reproduces the bug that was exposed by strict_comparison setting.


### PR DESCRIPTION
## 概要

`main` を含む全ブランチで CI が赤かった問題を修正します。元々は PHPStan ジョブのみ失敗していましたが、これを直したことで `needs` でブロックされていた下流ジョブが初めて実行され、既存問題が顕在化したため、本 PR でまとめて対応します。さらにレビューで判明したポリフィル本体の OOM バグも修正します。

いずれも setup-php / rector の bump 自体が原因ではなく、**既存の問題が露呈した**ものです。

## 修正内容

### 1. PHPStan: `enum_exists('RoundingMode')` always-false (13 件)

Rector 2.4+ は scoped polyfill で global な `class RoundingMode` を `class_alias` 登録します。PHPStan の Better Reflection は `\RoundingMode` を本パッケージの enum (`lib/RoundingMode.php`) ではなくこの class に束縛するため、PHP 8.1 環境で `enum_exists('RoundingMode')` が「常に false」と静的推論され `function.impossibleType` エラーになります。

実行時は composer の files autoload で enum が先に読み込まれるためガードは正当です(issue #56 で対応済みの runtime 衝突とは別の純粋な静的解析アーティファクト)。issue #56 で追加済みの他の ignore と同方針で `phpstan.neon.dist` に追加しました。

### 2. macOS: Setup PHP 失敗

`shivammathur/setup-php` 2.37.1 は macOS で brew tap の trust 不備により PHP セットアップに失敗します(`sed/grep/php: command not found` → `Could not setup PHP`)。2.37.2 の「Fixed macOS setup by marking `shivammathur/php` and `shivammathur/extensions` as trusted taps」で修正済みのため、全ワークフロー(6 箇所)を 2.37.2 へ更新しました。**dependabot PR #72 と同内容**のため、本 PR マージ後 #72 は自動クローズされます。

### 3. bcround() の巨大 precision での OOM(ポリフィル本体バグ)+ Docker PHPT

`bcround()` は INT_MAX (2147483647) を超える precision に対し `bcroundHelper()` 内の `str_repeat()` で巨大文字列を生成し**メモリ枯渇 Fatal error**(`src/BCMath.php` で `tried to allocate 9223372036854775839 bytes`)を起こしていました。

- **本体修正**: PHP 8.4+ の native `bcround()` 同様、precision が INT_MAX 超の場合は計算前に `ValueError` を投げるよう `BCMath::round()` に境界チェックを追加(php-src の `bcmath_check_precision` を踏襲、上限のみ判定)。メッセージも native と一致(`must be between -9223372036854775808 and 2147483647`)。ユニットテスト `testRoundPrecisionAboveIntMaxThrows` を追加。
- **Docker PHPT**: php-src master の `bcround_precision_bounds.phpt` は `BcMath\Number` OOP API も使用しますが本ポリフィルは未実装のため、他の `BcMath\Number` 依存テストと同様 skip list へ追加。

> 補足: precision 境界チェックは php-src master (8.6) の追加で、リリース済み bcmath (8.5 等) は依然 OOM します。そのためテストでは native `bcround()` とのクロスチェックは行わずポリフィル単体を検証しています。

## 検証

- PHPStan: 前回の CI (PHP 8.1 + rector 2.4.x) で **pass** 済み。
- ローカル: `vendor/bin/phpunit` 全 276 件 pass、`php-cs-fixer --dry-run --allow-risky=yes` 指摘 0、追加した `testRoundPrecisionAboveIntMaxThrows` も pass。
- macOS / Docker PHPT / 全マトリクス: 本 PR の CI で確認します。

Closes #56 のフォローアップ / Supersedes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)